### PR TITLE
Potential fix for code scanning alert no. 2019: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2019](https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2019)

The problem should be fixed by adding an explicit `permissions` block to limit the `GITHUB_TOKEN` scope. The best way to do this is to set `permissions: contents: read` at the root of the workflow file, ensuring that all jobs default to the least privileges necessary (read-only), unless an individual job requires more. This can be implemented by adding the `permissions` block after the `name` key but before the `on` key in `.github/workflows/docker-image.yml`. No imports or additional methods are required—this is a YAML metadata change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
