### PR TITLE
Potential fix for code scanning alert no. 2021: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2021](https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2021)

To resolve the issue, explicitly add a `permissions` block to the workflow. In most static analysis workflows (like this Pylint configuration), only read access to repository contents is necessary.  
The best way to achieve this is to add a top-level `permissions:` key with `contents: read` under the workflow name, applying least privilege to all jobs in the workflow. No changes to the logic of the workflow are required and there is no risk of breaking existing behavior. The edit should be just after the `name:` line and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
