### PR TITLE
Potential fix for code scanning alert no. 2020: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,7 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions: {}
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2020](https://github.com/GreatestDisplayName/RLGymExampleBot/security/code-scanning/2020)

To fix this issue, we need to explicitly restrict the permissions used by the workflow or job. The recommended minimal starting point for workflows that do not interact with repository resources is to set the `permissions` key to disable all permissions (`permissions: {}`), or to specify only those permissions required. Since the example workflow only prints a string and does not require any permissions, we should add `permissions: {}` to either the workflow root (before `jobs:`) or to the individual job (`greet`). The preferred method is to add it at the root, so all jobs inherit these restricted permissions unless explicitly overridden. This involves adding a block like:

```yaml
permissions: {}
```

after the `name` or just before `jobs:` in `.github/workflows/manual.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
